### PR TITLE
Ensure that imported family members end up in the same family.

### DIFF
--- a/Excavator.CSV/CSVComponent.cs
+++ b/Excavator.CSV/CSVComponent.cs
@@ -92,6 +92,8 @@ namespace Excavator.CSV
         /// </summary>
         private List<Group> ImportedFamilies;
 
+        private List<Group> NewFamilies = new List<Group>();
+
         /// <summary>
         /// The list of current campuses
         /// </summary>


### PR DESCRIPTION
If in a CSV you had three family members that belonged to the same family consecutively and the family hadn't been created then they would end up in three separate families. Not 🆒 .

This PR ensures that families that are created are tracked in memory. It also fixes a number of Resharper identified code issues including unuused variables, a lack of null checking, and using more specific variable typing than necessary.